### PR TITLE
Add IPFS CID

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,11 @@ You can download the weights using a torrent client and this magnet link:
 magnet:?xt=urn:btih:5f96d43576e3d386c9ba65b883210a393b68210e&tr=https%3A%2F%2Facademictorrents.com%2Fannounce.php&tr=udp%3A%2F%2Ftracker.coppersurfer.tk%3A6969&tr=udp%3A%2F%2Ftracker.opentrackr.org%3A1337%2Fannounce
 ```
 
+Or using IPFS CID (blake3):
+```
+bafyb4id5xdepghz5pvplhylgz7scjkoefh4d34j4kdw2w5hzrblv3uwbw4
+```
+
 # License
 
 The code and associated Grok-1 weights in this release are licensed under the


### PR DESCRIPTION
I think IPFS is a good alternative to torrent for sharing large files.
It has already been successfully used to share/store llama's weights.

Command used to generate CID:
```shell
ipfs add grok-1 -r --hash blake3 --chunker size-1048576
```

I recommend pinning grok-1 weights yourself before merging to check the correctness of my CID.