### PR TITLE
[Fix] Could not find a version that satisfies the requirement jaxlib==0.4.25+cuda12.cudnn89

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,16 +2,9 @@
 
 This repository contains JAX example code for loading and running the Grok-1 open-weights model.
 
-Make sure to download the checkpoint and place `ckpt-0` directory in `checkpoints` before run the project.
+Make sure to download the checkpoint and place the `ckpt-0` directory in `checkpoints` - see [Downloading the weights](#downloading-the-weights)
 
-## 1. Downloading the weights
-
-You can download the weights using a torrent client in the following magnet link:
-```
-magnet:?xt=urn:btih:5f96d43576e3d386c9ba65b883210a393b68210e&tr=https%3A%2F%2Facademictorrents.com%2Fannounce.php&tr=udp%3A%2F%2Ftracker.coppersurfer.tk%3A6969&tr=udp%3A%2F%2Ftracker.opentrackr.org%3A1337%2Fannounce
-```
-
-## 2. Installation
+## 1. Installation
 
 1. Install the project dependencies
 
@@ -27,16 +20,41 @@ python run.py
 
 The script loads the checkpoint and samples from the model on a test input.
 
-Due to the large size of the model (314B/Billion parameters), a machine with enough GPU memory is required to test the model with the example code.
+Due to the large size of the model (314 Billion parameters), a machine with enough GPU memory is required to test the model with the example code.
 
 The implementation of the MoE layer in this repository is not efficient. The implementation was chosen to avoid the need for custom kernels to validate the correctness of the model.
 
-## 3. Requirements
+## 2. Model Specifications
 
-Make sure to attend the following requirements before run the project:
+Grok-1 is currently designed with the following specifications:
 
- - Needs either either a TPU or GPU (NVIDIA/AMD supported only)
- - They have to be 8 devices (in the context of TPUs (Tensor Processing Units) or GPUs (Graphics Processing Units), they are typically talking about having access to a total of 8 individual processing units)
+- **Parameters:** 314B
+- **Architecture:** Mixture of 8 Experts (MoE)
+- **Experts Utilization:** 2 experts used per token
+- **Layers:** 64
+- **Attention Heads:** 48 for queries, 8 for keys/values
+- **Embedding Size:** 6,144
+- **Tokenization:** SentencePiece tokenizer with 131,072 tokens
+- **Additional Features:**
+  - Rotary embeddings (RoPE)
+  - Supports activation sharding and 8-bit quantization
+- **Maximum Sequence Length (context):** 8,192 tokens
+- **TPU/GPU:** NVIDIA/AMD supported only
+
+## 4. Downloading the weights
+
+You can download the weights using a torrent client and this magnet link:
+
+```
+magnet:?xt=urn:btih:5f96d43576e3d386c9ba65b883210a393b68210e&tr=https%3A%2F%2Facademictorrents.com%2Fannounce.php&tr=udp%3A%2F%2Ftracker.coppersurfer.tk%3A6969&tr=udp%3A%2F%2Ftracker.opentrackr.org%3A1337%2Fannounce
+```
+
+or directly using [HuggingFace 🤗 Hub](https://huggingface.co/xai-org/grok-1):
+```
+git clone https://github.com/xai-org/grok-1.git && cd grok-1
+pip install huggingface_hub[hf_transfer]
+huggingface-cli download xai-org/grok-1 --repo-type model --include ckpt-0/* --local-dir checkpoints --local-dir-use-symlinks False
+```
 
 # License
 

--- a/README.md
+++ b/README.md
@@ -2,27 +2,41 @@
 
 This repository contains JAX example code for loading and running the Grok-1 open-weights model.
 
-Make sure to download the checkpoint and place `ckpt-0` directory in `checkpoint`.
-Then, run
+Make sure to download the checkpoint and place `ckpt-0` directory in `checkpoints` before run the project.
 
-```shell
-pip install -r requirements.txt
-python run.py
-```
+## 1. Downloading the weights
 
-to test the code.
-
-The script loads the checkpoint and samples from the model on a test input.
-
-Due to the large size of the model (314B parameters), a machine with enough GPU memory is required to test the model with the example code.
-The implementation of the MoE layer in this repository is not efficient. The implementation was chosen to avoid the need for custom kernels to validate the correctness of the model.
-
-# Downloading the weights
-
-You can download the weights using a torrent client and this magnet link:
+You can download the weights using a torrent client in the following magnet link:
 ```
 magnet:?xt=urn:btih:5f96d43576e3d386c9ba65b883210a393b68210e&tr=https%3A%2F%2Facademictorrents.com%2Fannounce.php&tr=udp%3A%2F%2Ftracker.coppersurfer.tk%3A6969&tr=udp%3A%2F%2Ftracker.opentrackr.org%3A1337%2Fannounce
 ```
+
+## 2. Installation
+
+1. Install the project dependencies
+
+```bash
+pip install -r requirements.txt
+```
+
+2. Run the project
+
+```bash
+python run.py
+```
+
+The script loads the checkpoint and samples from the model on a test input.
+
+Due to the large size of the model (314B/Billion parameters), a machine with enough GPU memory is required to test the model with the example code.
+
+The implementation of the MoE layer in this repository is not efficient. The implementation was chosen to avoid the need for custom kernels to validate the correctness of the model.
+
+## 3. Requirements
+
+Make sure to attend the following requirements before run the project:
+
+ - Needs either either a TPU or GPU (NVIDIA/AMD supported only)
+ - They have to be 8 devices (in the context of TPUs (Tensor Processing Units) or GPUs (Graphics Processing Units), they are typically talking about having access to a total of 8 individual processing units)
 
 # License
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-dm_haiku==0.0.12
-jax[cuda12_pip]==0.4.25 -f https://storage.googleapis.com/jax-releases/jax_cuda_releases.html
+dm-haiku==0.0.12
+jax[cuda12-pip]==0.4.25 -f https://storage.googleapis.com/jax-releases/jax_cuda_releases.html
 numpy==1.26.4
 sentencepiece==0.2.0


### PR DESCRIPTION
## Description 

Fix the following error on MacOs:

```bash
ERROR: Could not find a version that satisfies the requirement jaxlib==0.4.25+cuda12.cudnn89; extra == "cuda12_pip" (from jax[cuda12-pip]) (from versions: 0.4.17, 0.4.18, 0.4.19, 0.4.20, 0.4.21, 0.4.22, 0.4.23, 0.4.24, 0.4.25)
ERROR: No matching distribution found for jaxlib==0.4.25+cuda12.cudnn89; extra == "cuda12_pip"
```

## Reference
[24 - Error "Could not find a version that satisfies the requirement jaxlib==0.4.25+cuda12.cudnn89"](https://github.com/xai-org/grok-1/issues/24)