### PR TITLE
[style improvement] Replace usage of list() with []

### DIFF
--- a/checkpoint.py
+++ b/checkpoint.py
@@ -83,7 +83,7 @@ def fast_pickle(obj: Any, path: str) -> None:
 def load_tensors(shaped_arrays, directory, mesh_config, tensor_indices=None):
     """Loads a set of arrays."""
     pool = ThreadPoolExecutor(max_workers=32)
-    fs = list()
+    fs = []
     num_tensors = 0
     num_replicas = 1
     data_model_shards = math.prod(mesh_config)


### PR DESCRIPTION
During my code review, I noticed that **list()** was used to create empty lists in this specific section of the code, while the rest of the codebase consistently uses **[]**, which is a more concise and idiomatic way to create empty lists in Python. 

Upon further examination, it was observed that the use of **list()** did not serve any specific purpose. 

To maintain a uniform code style and enhance readability, I have made this modification to replace **list()** with **[]**. This change aims to ensure consistency and simplicity in the codebase.