### PR TITLE
Update README.md instructions to use quotes

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ or directly using [HuggingFace 🤗 Hub](https://huggingface.co/xai-org/grok-1):
 ```
 git clone https://github.com/xai-org/grok-1.git && cd grok-1
 pip install huggingface_hub[hf_transfer]
-huggingface-cli download xai-org/grok-1 --repo-type model --include ckpt-0/* --local-dir checkpoints --local-dir-use-symlinks False
+huggingface-cli download xai-org/grok-1 --repo-type model --include "ckpt-0/*" --local-dir checkpoints --local-dir-use-symlinks False
 ```
 
 # License


### PR DESCRIPTION
On MacOS, without quotes the command to download checkpoint files fails.

```
levneiman@Levs-MBP ~/code/grok-1
 % huggingface-cli download xai-org/grok-1 --repo-type model --include ckpt-0/* --local-dir checkpoints --local-dir-use-symlinks False 

zsh: no matches found: ckpt-0/*
```