### PR TITLE
Allows CPU-based execution

### DIFF
--- a/requirements-cpu.txt
+++ b/requirements-cpu.txt
@@ -1,0 +1,4 @@
+dm_haiku==0.0.12
+jax==0.4.25
+numpy==1.26.4
+sentencepiece==0.2.0


### PR DESCRIPTION
Adds CPU execution to grok-1 model demo


VERY SLOW!

No one should process real world workloads this way.


This is only meant for early dev work by those who don't have 8 x 40GB GPUs



```shell
pip install -r requirements-cpu.txt
sed -i 's/USE_CPU_ONLY = False/USE_CPU_ONLY = True/' run.py
python run.py
```


Still requires:
* 384GB RAM
* 1.5 minutes to load into memory
* 1.1 hours to "compile" grok-1 model
* 4.2 hours to sample first inference request


Even on a 72 core Xeon Server, these runtimes can require monk-like patience.

So the point isn't to run this end-to-end all day.

It's for developers with high-memory workstations who would rather get this code running slowly than not at all.

Hopefully someone uses this CPU-only workaround early on to bootstrap grok-1 into a more performant model that can eventually be more accessible to a larger pool of devs.


Note: Executing this on most CPUs will emit a series of false warnings about the 8 CPU sub-processes being "stuck". These error messages come from a hardcoded warning within Tensorflow that don't appear to be tuneable or suppressible.


Note 2: If memory usage swells too high, comment out this single line below in checkpoint.py. This reduces peak memory usage from >600GB to closer to ~320GB. The downside is a slightly slower initial load. Adding this "copy_to_shm" load strategy is likely a good time-to-memory trade-off on xAI's server, but may not be on your workstation if it triggers OOM.


```shell
def fast_unpickle(path: str) -> Any:
  #  with copy_to_shm(path) as tmp_path:
        with open(path, "rb") as f:
            return pickle.load(f)
```