### PR TITLE
Change subfunction signature to ignore `value`

### DIFF
--- a/model.py
+++ b/model.py
@@ -90,9 +90,7 @@ def ffn_size(emb_size, widening_factor):
 
 
 def apply_rules(rules):
-    def _apply_rules(path, value):
-        del value  # Unused.
-
+    def _apply_rules(path, _):
         path_list = [str(i.key).split("/") for i in path if isinstance(i, jax.tree_util.DictKey)]
         flattened_path = jax.tree_util.tree_flatten(path_list)[0]
 


### PR DESCRIPTION
Instead of marking `value` for deletion by doing
```py
del value  # Unused.
```

ignore the variable in the function signature.