### PR TITLE
Reproducible and automatically configure development environments

### DIFF
--- a/.env.public
+++ b/.env.public
@@ -1,0 +1,1 @@
+GROK_MAGNET_LINK=magnet:?xt=urn:btih:5f96d43576e3d386c9ba65b883210a393b68210e&tr=https%3A%2F%2Facademictorrents.com%2Fannounce.php&tr=udp%3A%2F%2Ftracker.coppersurfer.tk%3A6969&tr=udp%3A%2F%2Ftracker.opentrackr.org%3A1337%2Fannounce

--- a/.envrc
+++ b/.envrc
@@ -1,0 +1,4 @@
+dotenv .env.public
+dotenv_if_exists
+use flake
+layout python

--- a/.github/hooks/pre-commit
+++ b/.github/hooks/pre-commit
@@ -1,0 +1,3 @@
+#!/usr/bin/env bash
+
+ruff check ./

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,8 @@
+name: test
+on: [push, pull_request]
+jobs:
+  ruff:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: chartboost/ruff-action@v1

--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,5 @@
+/.direnv/
+/.venv/
 checkpoints/*
 !checkpoints/README.md
+__pycache__/

--- a/Justfile
+++ b/Justfile
@@ -1,0 +1,14 @@
+[private]
+@default:
+	just --list --unsorted
+
+# Run the sample prompt against the model
+test:
+	python run.py
+
+# Download the weights for the Grok model
+download-weights:
+	transmission-cli \
+		--download-dir ./checkpoints \
+		$GROK_MAGNET_LINK
+	ln -s ./checkpoints/grok-1/ckpt-0 ./checkpoints/ckpt-0

--- a/README.md
+++ b/README.md
@@ -49,6 +49,18 @@ pip install huggingface_hub[hf_transfer]
 huggingface-cli download xai-org/grok-1 --repo-type model --include ckpt-0/* --local-dir checkpoints --local-dir-use-symlinks False
 ```
 
+# Reproducible Environment
+
+Those familiar with `nix` and `direnv` can use a reproducible development environment.
+
+```sh
+cd ~/src/grok-1
+direnv allow .
+just --list
+just download-weights
+just test
+```
+
 # License
 
 The code and associated Grok-1 weights in this release are licensed under the

--- a/flake.lock
+++ b/flake.lock
@@ -1,0 +1,61 @@
+{
+  "nodes": {
+    "flake-utils": {
+      "inputs": {
+        "systems": "systems"
+      },
+      "locked": {
+        "lastModified": 1710146030,
+        "narHash": "sha256-SZ5L6eA7HJ/nmkzGG7/ISclqe6oZdOZTNoesiInkXPQ=",
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "rev": "b1d9ab70662946ef0850d488da1c9019f3a9752a",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "type": "github"
+      }
+    },
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1711124224,
+        "narHash": "sha256-l0zlN/3CiodvWDtfBOVxeTwYSRz93muVbXWSpaMjXxM=",
+        "owner": "nixos",
+        "repo": "nixpkgs",
+        "rev": "56528ee42526794d413d6f244648aaee4a7b56c0",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nixos",
+        "ref": "nixos-23.11",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "root": {
+      "inputs": {
+        "flake-utils": "flake-utils",
+        "nixpkgs": "nixpkgs"
+      }
+    },
+    "systems": {
+      "locked": {
+        "lastModified": 1681028828,
+        "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",
+        "owner": "nix-systems",
+        "repo": "default",
+        "rev": "da67096a3b9bf56a91d16901293e51ba5b49a27e",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-systems",
+        "repo": "default",
+        "type": "github"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/flake.nix
+++ b/flake.nix
@@ -1,0 +1,48 @@
+{
+  inputs = {
+    nixpkgs.url = "github:nixos/nixpkgs/nixos-23.11";
+    flake-utils.url = "github:numtide/flake-utils";
+  };
+
+  outputs = { self, nixpkgs, flake-utils }: flake-utils.lib.eachDefaultSystem (system:
+    let
+      pkgs = import nixpkgs { inherit system; };
+      python = pkgs.python311;
+    in
+    {
+      devShells.default = pkgs.mkShell {
+
+        # build-time
+        nativeBuildInputs = with pkgs; [
+          bashInteractive
+        ];
+
+        # run-time
+        buildInputs = (with pkgs; [
+          transmission
+          just
+        ]) ++ (with python.pkgs; [
+          setuptools
+          wheel
+          venvShellHook
+          pylint
+        ]);
+
+        # python setup
+        src = null;
+        venvDir = ".venv";
+        postVenv = ''
+          unset SOURCE_DATE_EPOCH
+        '';
+        postShellHook = ''
+          # python setup
+          unset SOURCE_DATE_EPOCH
+          unset LD_PRELOAD
+          PYTHONPATH=$PWD/$venvDir/${python.sitePackages}:$PYTHONPATH
+          pip install --require-virtualenv -r requirements.txt | grep -v 'already satisfied'
+        '';
+
+      };
+    }
+  );
+}

--- a/flake.nix
+++ b/flake.nix
@@ -25,7 +25,7 @@
           setuptools
           wheel
           venvShellHook
-          pylint
+          pkgs.ruff
         ]);
 
         # python setup
@@ -35,11 +35,11 @@
           unset SOURCE_DATE_EPOCH
         '';
         postShellHook = ''
-          # python setup
           unset SOURCE_DATE_EPOCH
           unset LD_PRELOAD
           PYTHONPATH=$PWD/$venvDir/${python.sitePackages}:$PYTHONPATH
           pip install --require-virtualenv -r requirements.txt | grep -v 'already satisfied'
+          git config --local core.hooksPath .github/hooks
         '';
 
       };


### PR DESCRIPTION
To rapidly onboard new developers its best to provide a reproducible development environment.

This PR achieves the following:
- deterministic system dependencies using `nixpkgs` via `./flake.nix`
- automatic repo setup via `shellHook` in `./flake.nix` using cached `direnv` via `nix-direnv`
- lint checks using `ruff` both as git `pre-commit` and `.github/workflow/test.yml` for PRs and merges to master
- identified and provided repo tasks via `Justfile` (only 2 atm, but likely to grow)

**Concerns**

I couldnt download the 300+ GB model, so havent tested the `download-weights` task.
