### PR TITLE
added jaxlib specific version

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,5 @@
 dm_haiku==0.0.12
 jax[cuda12-pip]==0.4.25 -f https://storage.googleapis.com/jax-releases/jax_cuda_releases.html
+jaxlib==0.4.25
 numpy==1.26.4
 sentencepiece==0.2.0


### PR DESCRIPTION
In some cases, jaxlib will not install exact compatible version number.  specifying version in requirements avoids startup error.  I got this when running from PS on Windows 10.


The error message you're encountering, RuntimeError: jaxlib version 0.4.26 is newer than and incompatible with jax version 0.4.25. Please update your jax and/or jaxlib packages., indicates a version mismatch between jax and jaxlib. This is a common issue when the versions of these two packages are not compatible with each other. To resolve this issue, you need to ensure that both jax and jaxlib are updated to versions that are compatible.